### PR TITLE
allow TaskCluster to build 'public' pull requests

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -1,4 +1,5 @@
 version: 0
+allowPullRequests: public
 metadata:
   name: One-off System Add-ons Repo
   description: One-off System Add-ons CI Tasks


### PR DESCRIPTION
Trying to fix this message I'm seeing on the open PRs.

```
The `allowPullRequests` configuration for this repository (in `.taskcluster.yml` on the
default branch) does not allow starting tasks for this pull request.
```

Copying https://github.com/mozilla/qbrt/pull/23/commits/778781b14a66eb843dce635c72e21dc8e43891b8
